### PR TITLE
Use a PAT for syncing with the upstream.

### DIFF
--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -33,6 +33,7 @@ jobs:
           DEBUG=1 gh repo sync $REPOSITORY -b $BRANCH_NAME --force
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           BRANCH_NAME: ${{ github.ref_name }}
 

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -19,21 +19,21 @@ jobs:
 
       - name: Authenticate GitHub CLI
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+          echo ${{ secrets.TEMP_ONGOV_ARIES_ACAPY_PLUGINS_REPO_SYNC_PAT }} | gh auth login --with-token
 
       - name: Debug Environment
         run: |
           gh auth status
           gh repo view ongov/aries-acapy-plugins --json name,owner
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEMP_ONGOV_ARIES_ACAPY_PLUGINS_REPO_SYNC_PAT }}
 
       - name: Sync repository with the upstream
         run: |
           DEBUG=1 gh repo sync $REPOSITORY -b $BRANCH_NAME --force
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEMP_ONGOV_ARIES_ACAPY_PLUGINS_REPO_SYNC_PAT }}
+          GH_TOKEN: ${{ secrets.TEMP_ONGOV_ARIES_ACAPY_PLUGINS_REPO_SYNC_PAT }}
           REPOSITORY: ${{ github.repository }}
           BRANCH_NAME: "main"
 

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          BRANCH_NAME: ${{ github.ref_name }}
+          BRANCH_NAME: "main"
 
       - name: Send notification on sync failure
         if: failure()


### PR DESCRIPTION
Added a PAT with limited scope to allow the repo sync to succeed. A side effect is that it runs as me (donato-ods-devops).