### PR TITLE
Resolve propagation delay when mounting Azure Files

### DIFF
--- a/status_list/status_list/v1_0/controllers/status_list_pub.py
+++ b/status_list/status_list/v1_0/controllers/status_list_pub.py
@@ -84,7 +84,7 @@ async def publish_status_list(request: web.BaseRequest):
                     did=definition.issuer_did,
                     verification_method=definition.verification_method,
                 )
-                status_handler.write_to_file(path, jws.encode("utf-8"))
+                status_handler.write_to_file(path, jws.encode("utf-8"), with_alt=True)
             # add status_list to published list
             published.append(status_list)
 

--- a/status_list/status_list/v1_0/tests/test_status_handler.py
+++ b/status_list/status_list/v1_0/tests/test_status_handler.py
@@ -59,7 +59,7 @@ def test_write_to_file_success(tmp_path):
     file_path = tmp_path / "test.txt"
     content = b"hello world"
 
-    status_handler.write_to_file(str(file_path), content)
+    status_handler.write_to_file(str(file_path), content, with_alt=True)
 
     assert file_path.exists()
     assert file_path.read_bytes() == content
@@ -79,7 +79,7 @@ def test_write_to_file_success(tmp_path):
     original_replace = os.replace
 
     with patch("status_list.v1_0.status_handler.os.replace", side_effect=flaky_replace):
-        status_handler.write_to_file(str(file_path), content)
+        status_handler.write_to_file(str(file_path), content, with_alt=True)
 
     assert file_path.exists()
     assert file_path.read_bytes() == content
@@ -92,7 +92,7 @@ def test_write_to_file_success(tmp_path):
         "status_list.v1_0.status_handler.os.replace", side_effect=OSError("always fail")
     ):
         with pytest.raises(OSError, match="always fail"):
-            status_handler.write_to_file(str(file_path), content)
+            status_handler.write_to_file(str(file_path), content, with_alt=True)
 
     # Final file should not exist
     assert not file_path.exists()
@@ -105,7 +105,7 @@ def test_write_to_file_success(tmp_path):
         "status_list.v1_0.status_handler.FileLock", side_effect=Timeout("lock timeout")
     ):
         with pytest.raises(Timeout, match="lock timeout"):
-            status_handler.write_to_file(str(file_path), content)
+            status_handler.write_to_file(str(file_path), content, with_alt=True)
 
     assert not file_path.exists()
 


### PR DESCRIPTION

This pull request enhances the atomic file writing logic in the status list module to support writing an alternative `.alt` sibling file for redundancy or fallback, and improves cleanup and error handling. It also updates the relevant tests to use the new functionality. The most important changes are grouped below:

**File Write Logic Improvements:**

* The `write_to_file` function now supports an optional `with_alt` parameter to atomically write both the main file and an alternative `.alt` sibling file, improving reliability in file publishing. The function also uses more robust cleanup for temporary and lock files, and introduces delayed deletion of the `.alt` file.
* Added helper functions `alt_name` (to generate the alternative filename) and `unlink_file` (for safe file deletion with optional delay).
* The decorator `with_retries` was refactored for improved type safety and documentation.

**Integration and Usage:**

* The `publish_status_list` controller now calls `write_to_file` with `with_alt=True` to publish both the main and `.alt` files.

**Testing Updates:**

* All relevant tests in `test_status_handler.py` now invoke `write_to_file` with `with_alt=True` to verify the new behavior and ensure correctness under normal and error conditions. [[1]](diffhunk://#diff-57c5deedcc16f5421ffd74add533e6f5a4110be9806da235a9ffb4248b68d6c1L62-R62) [[2]](diffhunk://#diff-57c5deedcc16f5421ffd74add533e6f5a4110be9806da235a9ffb4248b68d6c1L82-R82) [[3]](diffhunk://#diff-57c5deedcc16f5421ffd74add533e6f5a4110be9806da235a9ffb4248b68d6c1L95-R95) [[4]](diffhunk://#diff-57c5deedcc16f5421ffd74add533e6f5a4110be9806da235a9ffb4248b68d6c1L108-R108)

These changes collectively make file publishing more robust and add support for alternative file outputs, while ensuring the codebase and tests are updated accordingly.